### PR TITLE
Update nikto Dockerfile

### DIFF
--- a/nikto/Dockerfile
+++ b/nikto/Dockerfile
@@ -22,7 +22,7 @@ RUN git clone https://github.com/sullo/nikto.git && \
     mv program /usr/share/nikto && \
     cd /usr/share/nikto && \
     rm -rf /tmp/nikto && \
-    mv nikto.conf /etc/nikto.conf && \
+    mv nikto.conf.default /etc/nikto.conf && \
     mv nikto.pl /usr/bin/nikto && \
     echo "EXECDIR=/usr/share/nikto" >> /etc/nikto.conf
 


### PR DESCRIPTION
The upstream git repo for nikto now has `nikto.conf.default` as oppose to `nikto.conf` :
[aqui/here](https://github.com/sullo/nikto/tree/master/program)